### PR TITLE
comment out a break that was not properly Goosed all along

### DIFF
--- a/fh/nfs_fh.go
+++ b/fh/nfs_fh.go
@@ -42,7 +42,7 @@ func Equal(h1 nfstypes.Nfs_fh3, h2 nfstypes.Nfs_fh3) bool {
 	for i, x := range h1.Data {
 		if x != h2.Data[i] {
 			equal = false
-			break
+			// break FIXME not supported by Goose
 		}
 	}
 	return equal


### PR DESCRIPTION
This is required to make it still Goose with https://github.com/tchajed/goose/pull/25.

Range loops do not support break anyway, so this was ignored in the Goose'd code all along. (I guess this means the real code ran faster than the code that was actually verified -- the early-break optimization was not verified.)